### PR TITLE
Refactor: next/head 내에 meta 선언 대신 viewPort export로 대체

### DIFF
--- a/app/(pages)/(main)/layout.tsx
+++ b/app/(pages)/(main)/layout.tsx
@@ -11,7 +11,7 @@ export default function MainLayout({
       <Script
         type="text/javascript"
         src={`https://oapi.map.naver.com/openapi/v3/maps.js?ncpClientId=${process.env.NEXT_PUBLIC_NAVER_MAP_CLIENT_ID}&submodules=geocoder`}
-      ></Script>
+      />
       {children}
       <Footer />
     </div>

--- a/app/(pages)/layout.tsx
+++ b/app/(pages)/layout.tsx
@@ -8,10 +8,9 @@ const MyCurationModalProvider = dynamic(
     )
 );
 import getMyCuration from "@feature/curation/queries/getMyCuration";
+import { Viewport } from "next";
 import dynamic from "next/dynamic";
 import localFont from "next/font/local";
-import Head from "next/head";
-import Script from "next/script";
 import { twMerge } from "tailwind-merge";
 
 const globalFont = localFont({
@@ -45,6 +44,13 @@ export const metadata = {
   description: "키워드로 내가 원하는 공간을 찾아보세요!",
 };
 
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+};
+
 export default async function RootLayout({
   children,
 }: {
@@ -53,12 +59,6 @@ export default async function RootLayout({
   const myCurationData = await getMyCuration();
   return (
     <html lang="en" className="width-[100%] height-[100%]">
-      <Head>
-        <meta
-          name="viewport"
-          content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-        />
-      </Head>
       <body className={twMerge("w-[100%] h-[100%]", globalFont.variable)}>
         <main className="w-[100%] h-[100%] fixed overflow-hidden">
           <RecoilRootLayout>

--- a/app/(pages)/layout.tsx
+++ b/app/(pages)/layout.tsx
@@ -10,6 +10,8 @@ const MyCurationModalProvider = dynamic(
 import getMyCuration from "@feature/curation/queries/getMyCuration";
 import dynamic from "next/dynamic";
 import localFont from "next/font/local";
+import Head from "next/head";
+import Script from "next/script";
 import { twMerge } from "tailwind-merge";
 
 const globalFont = localFont({
@@ -51,10 +53,12 @@ export default async function RootLayout({
   const myCurationData = await getMyCuration();
   return (
     <html lang="en" className="width-[100%] height-[100%]">
-      <meta
-        name="viewport"
-        content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-      />
+      <Head>
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+        />
+      </Head>
       <body className={twMerge("w-[100%] h-[100%]", globalFont.variable)}>
         <main className="w-[100%] h-[100%] fixed overflow-hidden">
           <RecoilRootLayout>


### PR DESCRIPTION
 next/head 내에 meta 선언 대신 viewPort export로 대체(deprecated issue)